### PR TITLE
Generate fragment for missing static refs to prevent error page

### DIFF
--- a/src/Zicht/Bundle/UrlBundle/Twig/UrlExtension.php
+++ b/src/Zicht/Bundle/UrlBundle/Twig/UrlExtension.php
@@ -105,7 +105,7 @@ class UrlExtension extends \Twig_Extension
             try {
                 $this->static_refs[$name] = $this->provider->url($name);
             } catch (UnsupportedException $e) {
-                $this->static_refs[$name] = '/[static_reference: '. $name . ']';
+                $this->static_refs[$name] = '#static_reference:' . $name;
             }
         }
 


### PR DESCRIPTION
Generate a URL fragment, like `#static_reference:name`, for missing static refs to be more friendly and prevent a 404 error because a URL like www.example.com/[static_reference:%20name] is not found.

When `$params` are passed in, these will be placed after the fragment. According to the [URI RFC](https://tools.ietf.org/html/rfc3986) the fragment starts at `#` until the end of the URI (and thus can contain `?`, `&`, `=` etc.). When a static ref is missing and `$params` are passed in, this will result in `#static_reference:name?param1=value1&param2=value2` instead of `/[static_reference:%20name]?param1=value1&param2=value2`, which I still consider an improvement.

Targetting 2.x branch with the intention to push this change up to 3.x and 4.x branches after merge.