### PR TITLE
Fix Tinymce Type Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 4.1.1 - 2020-04-28
+### Changed
+- Made TinymceTypeExtension getExtensionType return the actual type class instead of its own class name
+- Removed deprecated alias attribute of the form.type_extension tag of the TinymceTypeExtension service definition
+
 ## 4.1.0 - 2019-10-03
 - Added _mode_ column and filter to the URL Alias admin
 

--- a/src/Zicht/Bundle/UrlBundle/Form/Extension/TinymceTypeExtension.php
+++ b/src/Zicht/Bundle/UrlBundle/Form/Extension/TinymceTypeExtension.php
@@ -7,6 +7,7 @@ namespace Zicht\Bundle\UrlBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
+use Zicht\Bundle\AdminBundle\Form\TinymceType;
 use Zicht\Bundle\UrlBundle\Form\DataTransformer\HtmlTransformer;
 use Zicht\Bundle\UrlBundle\Aliasing\Aliasing;
 
@@ -26,13 +27,11 @@ class TinymceTypeExtension extends AbstractTypeExtension
     }
 
     /**
-     * Returns the name of the type being extended.
-     *
-     * @return string The name of the type being extended
+     * {@inheritDoc}
      */
     public function getExtendedType()
     {
-       return TinymceTypeExtension::class;
+       return TinymceType::class;
     }
 
     /**

--- a/src/Zicht/Bundle/UrlBundle/Resources/config/aliasing.xml
+++ b/src/Zicht/Bundle/UrlBundle/Resources/config/aliasing.xml
@@ -28,7 +28,7 @@
         </service>
         <service id="zicht_url.tinymce_type_extension" class="Zicht\Bundle\UrlBundle\Form\Extension\TinymceTypeExtension">
             <argument type="service" id="zicht_url.aliasing" />
-            <tag name="form.type_extension" extended-type="Zicht\Bundle\AdminBundle\Form\TinymceType" alias="tinymce" />
+            <tag name="form.type_extension" extended-type="Zicht\Bundle\AdminBundle\Form\TinymceType" />
         </service>
 
         <service id="zicht_url.alias_sitemap_provider" class="Zicht\Bundle\UrlBundle\Url\AliasSitemapProvider">


### PR DESCRIPTION
- Made TinymceTypeExtension getExtensionType return the actual type
  class instead of its own class name
- Removed deprecated alias attribute of the form.type_extension tag of
  the TinymceTypeExtension service definition