### PR TITLE
Added slash suffixed URL handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added|Changed|Deprecated|Removed|Fixed|Security
-Nothing so far
+- Added slash suffixed URL handling options (ignore, allow, redirect temporary, redirect permanently)
+- Fixed bug #60 (with enable_params enabled, query string would be stripped off and an url alias with query string was not possible)
+- Minor code cleanup in Listener
+- Fixed maintainers
 
-## 2.20.0
+## 2.20.1 - 2020-01-22
+- Also allow PHP ^7
 
+## 2.20.0 - 2020-01-22
 - Allows absolute urls to be generated natively through the symfony routing component, added support via the url providers and the
-  twig `object_url`  method.
+  twig `object_url` method.
 
 ## 2.19.2
 - remove itertools reference

--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ There is an event that makes it possible to modify the resultset of the sitemap;
 - `zicht_url.sitemap.filter`, which allows you to modify the result from the previous query and filter out items.
 
 # Maintainers
-* Philip Bergman <philip@zicht.nl>
 * Boudewijn Schoon <boudewijn@zicht.nl>
+* Jochem Klaver <jochem@zicht.nl>

--- a/src/Zicht/Bundle/UrlBundle/Aliasing/Aliasing.php
+++ b/src/Zicht/Bundle/UrlBundle/Aliasing/Aliasing.php
@@ -132,6 +132,33 @@ class Aliasing
         return $ret;
     }
 
+    /**
+     * @param string[] $publicUrls
+     * @param int|null $mode
+     * @return UrlAlias[]
+     */
+    public function getInternalAliases($publicUrls, $mode = null)
+    {
+        if (null !== $mode && !is_int($mode)) {
+            throw new \UnexpectedValueException(sprintf('Mode argument is expected to be an integer or null, %s given', gettype($mode)));
+        }
+        if (!is_iterable($publicUrls)) {
+            throw new \UnexpectedValueException(sprintf('Public URLs argument is expected to be an array of strings, %s given', gettype($publicUrls)));
+        }
+
+        if (count($publicUrls) === 0) {
+            return [];
+        }
+
+        $qb = $this->repository->createQueryBuilder('u');
+        $qb->where($qb->expr()->in('u.public_url', $publicUrls));
+        if (null !== $mode) {
+            $qb->andWhere($qb->expr()->eq('u.mode', (int)$mode));
+        }
+        $qb->indexBy('u', 'u.public_url');
+
+        return $qb->getQuery()->getResult();
+    }
 
     /**
      * Check if the passed internal URL has a public url alias.

--- a/src/Zicht/Bundle/UrlBundle/DependencyInjection/Configuration.php
+++ b/src/Zicht/Bundle/UrlBundle/DependencyInjection/Configuration.php
@@ -8,6 +8,7 @@ namespace Zicht\Bundle\UrlBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Zicht\Bundle\UrlBundle\Aliasing\Listener;
 
 /**
  * Configuration schema for the url bundle
@@ -45,6 +46,15 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('enabled')->defaultValue(false)->end()
                         ->booleanNode('enable_params')->defaultValue(false)->end()
+                        ->enumNode('slash_suffix_handling')
+                            ->values([
+                                Listener::SLASH_SUFFIX_ABSTAIN,
+                                Listener::SLASH_SUFFIX_ACCEPT,
+                                Listener::SLASH_SUFFIX_REDIRECT_PERM,
+                                Listener::SLASH_SUFFIX_REDIRECT_TEMP,
+                            ])
+                            ->defaultValue(Listener::SLASH_SUFFIX_ABSTAIN)
+                        ->end()
                         ->arrayNode('exclude_patterns')->prototype('scalar')->end()->end()
                         ->arrayNode('automatic_entities')->prototype('scalar')->end()->end()
                     ->end()

--- a/src/Zicht/Bundle/UrlBundle/DependencyInjection/ZichtUrlExtension.php
+++ b/src/Zicht/Bundle/UrlBundle/DependencyInjection/ZichtUrlExtension.php
@@ -101,6 +101,7 @@ class ZichtUrlExtension extends Extension
         }
 
         $listenerDefinition->addMethodCall('setIsParamsEnabled', array($aliasingConfig['enable_params']));
+        $listenerDefinition->addMethodCall('setSlashSuffixHandling', array($aliasingConfig['slash_suffix_handling']));
 
         if ($aliasingConfig['automatic_entities']) {
             $automaticAliasDoctrineDefinition = $container->getDefinition('zicht_url.aliasing.doctrine.subscriber');


### PR DESCRIPTION
* Added slash suffixed URL handling options (ignore, allow, redirect temporary, redirect permanently)
  This makes it possible to have a 301 redirect for `/public_url/` to `/public_url` which is more (SEO) friendly than having `/public_url/` result in a 404 error.
* Minor code cleanup in Listener
* Fixed maintainers

Resolves #60 