### PR TITLE
Sitemap template optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed bug #60 (with enable_params enabled, query string would be stripped off and an url alias with query string was not possible)
 - Minor code cleanup in Listener
 - Fixed maintainers
+- Optimized sitemap Twig template
 
 ## 2.20.1 - 2020-01-22
 - Also allow PHP ^7

--- a/src/Zicht/Bundle/UrlBundle/Resources/views/Sitemap/sitemap.xml.twig
+++ b/src/Zicht/Bundle/UrlBundle/Resources/views/Sitemap/sitemap.xml.twig
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    {% for url in urls %}
-        <url>
-            <loc>{{ app.request.schemeAndHttpHost }}{{ url.value }}</loc>
-        </url>
-    {% endfor %}
+{% for url in urls -%}
+    <url><loc>{{ app.request.schemeAndHttpHost }}{{ url.value }}</loc></url>
+{% endfor %}
 </urlset>


### PR DESCRIPTION
This small change to reduce white space reduces the file size of the sitemap.xml with 28%. In one project with almost 10,000 URLs in the sitemap, the file size has been reduced from 1,1M to 799K.

Changes output from:
```twig
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
            <url>
            <loc>https://example.org/page-one</loc>
        </url>
            <url>
            <loc>https://example.org/page-two</loc>
        </url>
    </urlset>
```
To:
```twig
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
<url><loc>https://example.org/page-one</loc></url>
<url><loc>https://example.org/page-two</loc></url>
</urlset>
```
