### PR TITLE
[TTC-622] Support to set the minimal length of the short url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
-### 4.2.0 - 2020-08-18
+## 4.2.1 - 2020-08-27
+### Fixed
+- Added missing `minLength` parameters to the `ShortUrlManager` and `UrlExtension::shortUrl`.
+
+## 4.2.0 - 2020-08-18
 ### Added
 - `ShortUrlManager` as an endpoint to handle easy to implement short versions for urls.
 - `UrlExtension::shortUrl` to integrate short urls in Twig.

--- a/src/Zicht/Bundle/UrlBundle/Twig/UrlExtension.php
+++ b/src/Zicht/Bundle/UrlBundle/Twig/UrlExtension.php
@@ -130,11 +130,12 @@ class UrlExtension extends \Twig_Extension
     /**
      * @param string $originatingUrl
      * @param string|null $prefix
+     * @param int $minLength
      * @return string
      */
-    public function shortUrl($originatingUrl, $prefix = null)
+    public function shortUrl($originatingUrl, $prefix = null, $minLength = 8)
     {
-        $alias = $this->shortUrlManager->getAlias($originatingUrl, $prefix);
+        $alias = $this->shortUrlManager->getAlias($originatingUrl, $prefix, $minLength);
         return $alias->getPublicUrl();
     }
 

--- a/src/Zicht/Bundle/UrlBundle/Url/ShortUrlManager.php
+++ b/src/Zicht/Bundle/UrlBundle/Url/ShortUrlManager.php
@@ -44,28 +44,28 @@ class ShortUrlManager
     /**
      * @param string $url
      * @param string|null $prefix
+     * @param int $minLength
      * @param int $mode
      * @return UrlAlias
      */
-    public function getAlias($url, $prefix = null, $mode = UrlAlias::MOVE)
+    public function getAlias($url, $prefix = null, $minLength = 8, $mode = UrlAlias::MOVE)
     {
         if ($prefix && false === strpos($prefix, '/')) {
             $prefix = sprintf('/%s', $prefix);
         }
 
-        $length = 8;
         do {
             // the hash will function as our public url
-            $hash = $this->shortUrlHashGenerator->generate($url, $length);
+            $hash = $this->shortUrlHashGenerator->generate($url, $minLength);
             $publicUrl = $prefix ? sprintf('%s/%s', $prefix, $hash) : $hash;
             $exists = $this->aliasing->getRepository()->findOneByPublicUrl($publicUrl, $mode);
             if ($exists && $exists->getInternalUrl() === $url) {
                 return $exists;
             }
-            $length++;
+            $minLength++;
             // sanely (sha256 consists of 64 chars) fail if we have a collision after numerous attempts. Something might be wronly implemented.
-            if ($length >= 65) {
-                throw new \LogicException(sprintf('Found a collision for a hash with %d chars. Something is not right.', $length));
+            if ($minLength >= 65) {
+                throw new \LogicException(sprintf('Found a collision for a hash with %d chars. Something is not right.', $minLength));
             }
         } while ($exists);
 


### PR DESCRIPTION
Het is nodig om zelf te bepalen hoeveel characters de short-url lang moet zijn.  Dit kan sterk afhangen van de functie van de url.  Ik gebruik het inmiddels ook voor een login token, dan is 8 characters een tikkeltje kort.