### PR TITLE
Fix UrlType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 7.0.3 - 2022-12-01
+### Fixed
+- Fixed UrlType to use the internal URL to be stored to the database
+- Fixed UrlType to be able to handle other values
+- Fix URL Alias entity `__toString()` to return public URL instead of ID
+
 ## 7.0.2 - 2022-12-01
 ### Added
 - Forward merge of v6.0.2: Sonata 4 form group labels
@@ -16,12 +22,12 @@ Nothing so far
 ### Changed
 - Alter `UrlType` to re-use `AutocompleteType` from `zicht/admin-bundle` to prevent multiple autocomplete implementations.
 
-  Add this to your `zicht_admin.yaml`:
+  Add this to your `zicht_admin.yaml` to override the default config:
 ```yaml
 zicht_admin:
     quicklist:
     ...
-    Zicht\Bundle\UrlBundle\Entity\UrlAlias:
+    url_alias:
         repository: 'Zicht\Bundle\UrlBundle\Entity\UrlAlias'
         fields: ['public_url']
 ```

--- a/src/Admin/UrlAliasAdmin.php
+++ b/src/Admin/UrlAliasAdmin.php
@@ -13,7 +13,6 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Zicht\Bundle\UrlBundle\Entity\UrlAlias;
-use Zicht\Bundle\UrlBundle\Type\UrlType;
 
 class UrlAliasAdmin extends AbstractAdmin
 {
@@ -63,7 +62,7 @@ class UrlAliasAdmin extends AbstractAdmin
     protected function configureFormFields(FormMapper $form): void
     {
         $form->add('public_url')
-            ->add('internal_url', UrlType::class, ['no_transform_public' => true])
+            ->add('internal_url')
             ->add(
                 'mode',
                 ChoiceType::class,

--- a/src/DependencyInjection/Compiler/AddUrlAliasAutocompleteRepositoryPass.php
+++ b/src/DependencyInjection/Compiler/AddUrlAliasAutocompleteRepositoryPass.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright Zicht Online <https://zicht.nl>
+ */
+
+namespace Zicht\Bundle\UrlBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Zicht\Bundle\UrlBundle\Entity\UrlAlias;
+
+/**
+ * Zicht Admin Quicklist service should have a 'url_alias' "repository". Either configure one in
+ * `config/packages/zicht_admin.yaml` or this Compiler Pass will add one.
+ */
+class AddUrlAliasAutocompleteRepositoryPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('zicht_admin.quicklist')) {
+            /** @var @see \Zicht\Bundle\AdminBundle\Service\Quicklist::addRepositoryConfig() */
+            $definition = $container->getDefinition('zicht_admin.quicklist');
+            if (0 === count(array_filter($definition->getMethodCalls(), static fn (array $call) => isset($call[0], $call[1][0]) && $call[0] === 'addRepositoryConfig' && $call[1][0] === 'url_alias'))) {
+                $definition->addMethodCall('addRepositoryConfig', ['url_alias', [
+                    'repository' => UrlAlias::class,
+                    'fields' => ['public_url'],
+                    'exposed' => false,
+                ]]);
+            }
+        }
+    }
+}

--- a/src/Entity/UrlAlias.php
+++ b/src/Entity/UrlAlias.php
@@ -140,6 +140,6 @@ class UrlAlias
      */
     public function __toString()
     {
-        return (string)$this->id;
+        return (string)$this->getPublicUrl();
     }
 }

--- a/src/Type/UrlType.php
+++ b/src/Type/UrlType.php
@@ -13,9 +13,7 @@ use Zicht\Bundle\UrlBundle\Aliasing\Aliasing;
 
 class UrlType extends AbstractType
 {
-    /**
-     * @var Aliasing
-     */
+    /** @var Aliasing */
     private $aliasing;
 
     public function __construct(Aliasing $aliasing)
@@ -30,7 +28,7 @@ class UrlType extends AbstractType
         $resolver
             ->setDefaults(
                 [
-                    'repo' => 'Zicht\Bundle\UrlBundle\Entity\UrlAlias',
+                    'repo' => 'url_alias',
                     'transformer' => 'noop', // disable all transformation. we do this ourselves with UrlTypeAutocompleteDataTransformer
                 ]
             );

--- a/src/Type/UrlTypeAutocompleteDataTransformer.php
+++ b/src/Type/UrlTypeAutocompleteDataTransformer.php
@@ -19,13 +19,15 @@ class UrlTypeAutocompleteDataTransformer implements DataTransformerInterface
         if (null === $value) {
             return $value;
         }
-        if (!$alias = $this->aliasing->getRepository()->findOneByPublicUrl($value)) {
-            return null;
+        if (!$alias = $this->aliasing->getRepository()->findOneByInternalUrl($value)) {
+            if (!$alias = $this->aliasing->getRepository()->findOneByPublicUrl($value)) {
+                return ['label' => $value, 'value' => $value, 'id' => $value];
+            }
         }
         // Return values that for AutocompleteType understands
         return [
             'label' => $alias->getPublicUrl(),
-            'value' => $alias->getPublicUrl(),
+            'value' => $alias->getInternalUrl(),
             'id' => $alias->getId(),
         ];
     }
@@ -34,7 +36,7 @@ class UrlTypeAutocompleteDataTransformer implements DataTransformerInterface
     {
         if (\is_numeric($value)) {
             $alias = $this->aliasing->getRepository()->find((int)$value);
-            return $alias->getPublicUrl();
+            return $alias->getInternalUrl();
         }
         return $value;
     }

--- a/src/ZichtUrlBundle.php
+++ b/src/ZichtUrlBundle.php
@@ -21,5 +21,6 @@ class ZichtUrlBundle extends Bundle
         $container->addCompilerPass(new DependencyInjection\Compiler\ReplaceUrlProviderServicePass());
         $container->addCompilerPass(new DependencyInjection\Compiler\CachePass());
         $container->addCompilerPass(new DependencyInjection\Compiler\UrlMapperPass());
+        $container->addCompilerPass(new DependencyInjection\Compiler\AddUrlAliasAutocompleteRepositoryPass());
     }
 }


### PR DESCRIPTION
Needed for the Zicht Admin autocomplete functionality introduced in v7.0.1. This renders a list using `(string)$record`:

```php
        $resultRecord = [
            'label' => (string)$record,
            'value' => (string)$record,
            'url' => ($admin ? $admin->generateObjectUrl('edit', $record) : null),
            'id' => ($admin ? $admin->id($record) : null),
        ];
```

Before:
![Screenshot from 2022-12-01 11-07-43](https://user-images.githubusercontent.com/2794908/205025677-d956ce1c-36b4-4b1d-9c7b-a5e0fc6a2984.png)

After:
![Screenshot from 2022-12-01 11-09-52](https://user-images.githubusercontent.com/2794908/205025792-eca6a8cd-9388-494f-8d5d-a76f80dd3921.png)
